### PR TITLE
Resolve deprecated warning for DataFrame.applymap

### DIFF
--- a/raha/dataset.py
+++ b/raha/dataset.py
@@ -55,7 +55,7 @@ class Dataset:
         This method reads a dataset from a csv file path.
         """
         dataframe = pandas.read_csv(dataset_path, sep=",", header="infer", encoding="utf-8", dtype=str,
-                                    keep_default_na=False, low_memory=False).applymap(self.value_normalizer)
+                                    keep_default_na=False, low_memory=False).map(self.value_normalizer)
         return dataframe
 
     @staticmethod


### PR DESCRIPTION
This PR fixes a FutureWarning since `DataFrame.applymap` is deprecated since `pandas==2.1.0`

```
/raha/dataset.py:58: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  keep_default_na=False, low_memory=False).applymap(self.value_normalizer)
```